### PR TITLE
fix: skip changeViewOption to preserve URL-derived rtl + declare disable

### DIFF
--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -69,4 +69,10 @@ jobs:
           done
           cd src
           pnpm exec playwright install chromium --with-deps
-          pnpm run test-ui --project=chromium
+          # Use the declared-disables helper instead of plain test-ui:
+          # ep.json declares `disables: ["@feature:line-numbers"]`, so the
+          # helper runs two passes — regression (everything not tagged
+          # @feature:line-numbers must pass) + honesty (every test
+          # tagged @feature:line-numbers must FAIL because the plugin
+          # genuinely keeps line numbers hidden). See doc/PLUGIN_FEATURE_DISABLES.md.
+          ../bin/run-frontend-tests-with-disables.sh -- --project=chromium

--- a/ep.json
+++ b/ep.json
@@ -1,4 +1,5 @@
 {
+  "disables": ["@feature:line-numbers"],
   "parts": [
     {
       "name": "hide_line_numbers",

--- a/static/js/hide_line_numbers.js
+++ b/static/js/hide_line_numbers.js
@@ -1,5 +1,28 @@
 'use strict';
 
-exports.postAceInit = () => {
-  pad.changeViewOption('showLineNumbers', false);
+// Hide the line-number gutter without going through pad.changeViewOption.
+//
+// Earlier revisions called `pad.changeViewOption('showLineNumbers', false)`
+// here, which works in isolation but has a nasty side-effect: core's
+// changeViewOption reads pad.padOptions, applies the one key being
+// changed, then re-runs setViewOptions for *all* options — falling
+// back to defaults for anything not persisted to pad.padOptions.
+//
+// The URL parameter `?rtl=true` is set by core via
+// `pad.changeViewOption('rtlIsTrue', true)` in pad.ts:postAceInit
+// *before* our hook fires, but core's changeViewOption doesn't write
+// rtlIsTrue back to pad.padOptions either — so when we later fire our
+// own changeViewOption call, the rtl override is lost and the
+// #options-rtlcheck checkbox flips back to unchecked.
+//
+// This broke rtl_url_param.spec.ts when ep_hide_line_numbers was
+// installed (#7658 surfaced the line-numbers half of the problem; this
+// is the other half).
+//
+// Fix: skip changeViewOption entirely. Tell ace directly + sync the
+// settings checkbox. No cascade through setViewOptions, so other
+// in-flight options (including the URL-derived rtl) are untouched.
+exports.postAceInit = (hook, context) => {
+  context.ace.setProperty('showslinenumbers', false);
+  $('#options-linenoscheck').prop('checked', false);
 };


### PR DESCRIPTION
## Summary

Two coupled changes that together unstick CI:

### 1. Real bug — `changeViewOption` cascade clobbers the URL-derived rtl

Earlier postAceInit called `pad.changeViewOption('showLineNumbers', false)`. Core's [`changeViewOption`](https://github.com/ether/etherpad-lite/blob/develop/src/static/js/pad.ts#L834) reads `pad.padOptions`, applies the one key being changed, then re-runs `setViewOptions` for **all** options — falling back to defaults for anything not persisted to `pad.padOptions`.

Core's own postAceInit sets the URL-derived rtl via `pad.changeViewOption('rtlIsTrue', settings.rtlIsTrue === true)` — but doesn't write it back to `pad.padOptions` either. So when our hook fires **after** core's, our `changeViewOption` call resets rtl back to default (`html10n.getDirection()`) and the URL param is silently dropped. This broke `rtl_url_param.spec.ts:11/16` whenever ep_hide_line_numbers was installed.

**Fix**: bypass `changeViewOption` entirely. Set the ace property directly + sync the settings checkbox. No `setViewOptions` cascade, so other in-flight options (including the URL-derived rtl) are untouched.

### 2. Contract — declare `@feature:line-numbers`

`ep.json` now declares `"disables": ["@feature:line-numbers"]`, and the workflow uses `bin/run-frontend-tests-with-disables.sh`. The two pad_settings specs that assert `not /line-numbers-hidden/` are tagged `@feature:line-numbers` (added in [etherpad-lite#7658](https://github.com/ether/etherpad/pull/7658)) and so are excluded from pass-1 regression and counted in pass-2 honesty.

## Companion

There's also an open PR #79 (the org-wide automerge-trigger fix). Once this lands and the plugin's CI is green, that one will go green automatically and can merge too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)